### PR TITLE
Fea: Add in memory request queue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.0.1",
 			"license": "ISC",
 			"dependencies": {
+				"@crawlee/memory-storage": "^3.11.1",
 				"@mozilla/readability": "^0.5.0",
 				"apify": "^3.2.3",
 				"cheerio": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"node": ">=18.0.0"
 	},
 	"dependencies": {
+		"@crawlee/memory-storage": "^3.11.1",
 		"@mozilla/readability": "^0.5.0",
 		"apify": "^3.2.3",
 		"cheerio": "^1.0.0",

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,0 +1,9 @@
+export enum CrawlerType {
+    CHEERIO_GOOGLE_SEARCH_CRAWLER = 'cheerio-google-search-crawler',
+    PLAYWRIGHT_CONTENT_CRAWLER = 'playwright-content-crawler',
+}
+
+export enum CrawlerQueueName {
+    CHEERIO_SEARCH_QUEUE = 'cheerio-search-queue',
+    PLAYWRIGHT_CONTENT_CRAWL_QUEUE = 'playwright-content-crawl-queue',
+}

--- a/src/crawlers.ts
+++ b/src/crawlers.ts
@@ -1,48 +1,29 @@
 import { MemoryStorage } from '@crawlee/memory-storage';
 import { RequestQueue } from 'apify';
 import { CheerioAPI } from 'cheerio';
-import { CheerioCrawlerOptions, RequestOptions,
+import {
+    CheerioCrawler,
+    CheerioCrawlerOptions,
     CheerioCrawlingContext,
     log,
-    PlaywrightCrawlingContext,
-    CheerioCrawler,
     PlaywrightCrawler,
     PlaywrightCrawlerOptions,
+    PlaywrightCrawlingContext,
+    RequestOptions,
 } from 'crawlee';
 import { ServerResponse } from 'http';
 
+import { CrawlerQueueName, CrawlerType } from './const.js';
 import { scrapeOrganicResults } from './google-extractors-urls.js';
 import { genericHandler } from './playwright-req-handler.js';
 import { createResponse } from './responses.js';
 import { PlaywrightScraperSettings, UserData } from './types.js';
 import { createRequest } from './utils.js';
 
-enum CrawlerType {
-    CHEERIO_GOOGLE_SEARCH_CRAWLER = 'cheerio-google-search-crawler',
-    PLAYWRIGHT_CONTENT_CRAWLER = 'playwright-content-crawler',
-}
-
 const crawlers = new Map<string, CheerioCrawler | PlaywrightCrawler>();
-// const queueSearchCrawler = await RequestQueue.open('cheerio-google-search-queue');
+const client = new MemoryStorage({ persistStorage: false });
 
 log.setLevel(log.LEVELS.DEBUG);
-
-// export const DEFAULT_CRAWLER_OPTIONS: CrawlerOptions = {
-//     proxyConfigurationOptions: {},
-// };
-//
-// export const DEFAULT_SCRAPER_SETTINGS: ScraperSettings = {
-//     dynamicContentWaitSecs: 0,
-//     maxHtmlCharsToProcess: 1.5e6,
-//     readableTextCharThreshold: 100,
-//     removeCookieWarnings: true,
-//     saveHtml: true,
-//     saveMarkdown: false,
-// };
-
-// Use crawlOptions to create a new CheerioCrawler (proxyConfiguration)
-// Proxy configuration for a PlaywrightCrawler
-// How to handle the case when all the requests are not finished?
 
 /**
  * Creates and starts a Google search crawler with the provided configuration.
@@ -57,12 +38,9 @@ export async function createAndStartSearchCrawler(
     playwrightScraperSettings: PlaywrightScraperSettings,
     startCrawler: boolean = true,
 ) {
-    const client = new MemoryStorage();
-    const queue = await RequestQueue.open(undefined, { storageClient: client });
-
     const crawler = new CheerioCrawler({
         ...(cheerioCrawlerOptions as CheerioCrawlerOptions),
-        requestQueue: queue,
+        requestQueue: await RequestQueue.open(CrawlerQueueName.CHEERIO_SEARCH_QUEUE, { storageClient: client }),
         requestHandler: async ({ request, $: _$ }: CheerioCrawlingContext<UserData>) => {
             // NOTE: we need to cast this to fix `cheerio` type errors
             const $ = _$ as CheerioAPI;
@@ -101,7 +79,7 @@ export async function createAndStartCrawlerPlaywright(
         ...(crawlerOptions as PlaywrightCrawlerOptions),
         requestHandler: (context: PlaywrightCrawlingContext) => genericHandler(context, settings),
         keepAlive: crawlerOptions.keepAlive,
-        requestQueue: await RequestQueue.open(),
+        requestQueue: await RequestQueue.open(CrawlerQueueName.PLAYWRIGHT_CONTENT_CRAWL_QUEUE, { storageClient: client }),
         autoscaledPoolOptions: { desiredConcurrency: 3 },
     });
 

--- a/src/crawlers.ts
+++ b/src/crawlers.ts
@@ -1,3 +1,4 @@
+import { MemoryStorage } from '@crawlee/memory-storage';
 import { RequestQueue } from 'apify';
 import { CheerioAPI } from 'cheerio';
 import { CheerioCrawlerOptions, RequestOptions,
@@ -22,7 +23,7 @@ enum CrawlerType {
 }
 
 const crawlers = new Map<string, CheerioCrawler | PlaywrightCrawler>();
-const queueSearchCrawler = await RequestQueue.open('cheerio-google-search-queue');
+// const queueSearchCrawler = await RequestQueue.open('cheerio-google-search-queue');
 
 log.setLevel(log.LEVELS.DEBUG);
 
@@ -56,9 +57,12 @@ export async function createAndStartSearchCrawler(
     playwrightScraperSettings: PlaywrightScraperSettings,
     startCrawler: boolean = true,
 ) {
+    const client = new MemoryStorage();
+    const queue = await RequestQueue.open(undefined, { storageClient: client });
+
     const crawler = new CheerioCrawler({
         ...(cheerioCrawlerOptions as CheerioCrawlerOptions),
-        requestQueue: queueSearchCrawler,
+        requestQueue: queue,
         requestHandler: async ({ request, $: _$ }: CheerioCrawlingContext<UserData>) => {
             // NOTE: we need to cast this to fix `cheerio` type errors
             const $ = _$ as CheerioAPI;


### PR DESCRIPTION
There is a preference for using memory storage, as in the SuperScraper, because it is slightly faster and eliminates the need for a named queue, preventing queue collisions and the need for manual deletion