### PR TITLE
docs: update readme min concurrency

### DIFF
--- a/.actor/input_schema.json
+++ b/.actor/input_schema.json
@@ -76,7 +76,7 @@
             "description": "Initial number of Playwright browsers running in parallel. The system scales this value based on CPU and memory usage.",
             "minimum": 0,
             "maximum": 50,
-            "default": 3
+            "default": 5
         },
         "minConcurrency": {
             "title": "Minimal concurrency",
@@ -84,7 +84,7 @@
             "description": "Minimum number of Playwright browsers running in parallel. Useful for defining a base level of parallelism.",
             "minimum": 1,
             "maximum": 50,
-            "default": 10
+            "default": 3
         },
         "maxConcurrency": {
             "title": "Maximal concurrency",

--- a/.actor/input_schema.json
+++ b/.actor/input_schema.json
@@ -111,7 +111,6 @@
             "default": 30
         },
         "dynamicContentWaitSecs": {
-            "sectionCaption": "HTML processing",
             "title": "Wait for dynamic content (seconds)",
             "type": "integer",
             "description": "Maximum time (in seconds) to wait for dynamic content to load. The crawler processes the page once this time elapses or when the network becomes idle.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 This changelog summarizes all changes of the RAG Web Browser
 
+### 2024-09-24
+
+🚀 Features
+- Updated README.md to include tips on improving latency
+- Set initialConcurrency to 5
+- Set minConcurrency to 3
+- Set logLevel to INFO
+
 ### 2024-09-20
 
 🐛 Bug Fixes

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Results were averaged for the three queries.
 
 Based on your requirements, if low latency is a priority, consider running the Actor with 4GB or 8GB of memory.
 However, if you're looking for a cost-effective solution, you can run the Actor with 2GB of memory, but you may experience higher latency and might need to set a longer timeout.
+
 If you need to gather more results, you can increase the memory and adjust the `initialConcurrency` parameter accordingly.
 
 ## 🎢 How to optimize the RAG Web Browser for low latency?

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ When running in the standby mode the RAG Web Browser accepts the following query
 | parameter                        | description                                                                                                                                            |
 |----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `query`                          | Use regular search words or enter Google Search URLs. You can also apply advanced Google search techniques.                                            |
-| `maxResults`                     | The number of top organic search results to return and scrape text from.                                                                               |
+| `maxResults`                     | The number of top organic search results to return and scrape text from (maximum is 50).                                                               |
 | `outputFormats`                  | Select the desired output formats for the retrieved content (e.g., "text", "markdown", "html").                                                        |
 | `requestTimeoutSecs`             | The maximum time (in seconds) allowed for the request. If the request exceeds this time, it will be marked as failed.                                  |
 | `proxyGroupSearch`               | Select the proxy group for loading search results. Options: 'GOOGLE_SERP', 'SHADER'.                                                                   |
@@ -98,9 +98,11 @@ The Standby mode allows the Actor to stay active, enabling it to retrieve result
 
 ## ⏳ What is the expected latency?
 
-The latency is proportional to the memory allocated to the Actor and number of results requested.
+The latency is proportional to the **memory allocated** to the Actor and **number of results requested**.
 
-Here is a typical latency breakdown for the RAG Web Browser.
+Below is a typical latency breakdown for the RAG Web Browser with **initialConcurrency=3** and **maxResults** set to either 1 or 3.
+These settings allow for processing all search results in parallel.
+
 Please note the these results are only indicative and may vary based on the search term, the target websites,
 and network latency.
 
@@ -116,12 +118,13 @@ Results were averaged for the three queries.
 
 Based on your requirements, if low latency is a priority, consider running the Actor with 4GB or 8GB of memory.
 However, if you're looking for a cost-effective solution, you can run the Actor with 2GB of memory, but you may experience higher latency and might need to set a longer timeout.
+If you need to gather more results, you can increase the memory and adjust the `initialConcurrency` parameter accordingly.
 
 ## 🎢 How to optimize the RAG Web Browser for low latency?
 
 For low latency, it's recommended to run the RAG Web Browser with 8 GB of memory. Additionally, adjust these settings to further optimize performance:
 
-- **Initial Concurrency**: This controls the number of Playwright browsers running in parallel. If you only need a few results (e.g., three), set the initial concurrency to match this number to ensure content is processed simultaneously.
+- **Initial Concurrency**: This controls the number of Playwright browsers running in parallel. If you only need a few results (e.g., 3, 5, or 10), set the initial concurrency to match this number to ensure content is processed simultaneously.
 - **Dynamic Content Wait Secs**: Set this to 0 if you don't need to wait for dynamic content. This can significantly reduce latency.
 - **Remove Cookie Warnings**: If the websites you're scraping don't have cookie warnings, set this to false to slightly improve latency.
 - **Debug Mode**: Enable this to store debugging information if you need to measure the Actor's latency.

--- a/README.md
+++ b/README.md
@@ -25,11 +25,15 @@ This allows the Actor to stay active, enabling it to retrieve results with lower
 
 ### 🔥 How to start the Actor in a Standby mode?
 
-You need the Actor's standby URL and `APIFY_API_TOKEN`.
-Then, you can send requests to the `/search` path along with your `query` and the number of results (`maxResults`) you want to retrieve.
+You need know the Actor's standby URL and `APIFY_API_TOKEN` to start the Actor in Standby mode.
 
 ```shell
-curl -X GET https://rag-web-browser.apify.actor?token=APIFY_API_TOKEN?query=apify
+curl -X GET https://rag-web-browser.apify.actor?token=APIFY_API_TOKEN
+```
+
+Then, you can send requests to the `/search` path along with your `query` and the number of results (`maxResults`) you want to retrieve.
+```shell
+curl -X GET https://rag-web-browser.apify.actor/search?token=APIFY_API_TOKEN&query=apify&maxResults=1
 ```
 
 Here’s an example of the server response (truncated for brevity):
@@ -63,7 +67,7 @@ Here’s an example of the server response (truncated for brevity):
 The Standby mode has several configuration parameters, such as Max Requests per Run, Memory, and Idle Timeout.
 You can find the details in the [Standby Mode documentation](https://docs.apify.com/platform/actors/running/standby#how-do-i-customize-standby-configuration).
 
-**Note** Sending a search request to /search will also initiate Standby mode.
+**Note** Sending a search request to `/search` will also initiate Standby mode.
 You can use this endpoint for both purposes conveniently
 ```shell
 curl -X GET https://rag-web-browser.apify.actor/search?token=APIFY_API_TOKEN?query=apify%20llm

--- a/src/crawlers.ts
+++ b/src/crawlers.ts
@@ -22,8 +22,6 @@ import { addTimeMeasureEvent, createRequest } from './utils.js';
 const crawlers = new Map<string, CheerioCrawler | PlaywrightCrawler>();
 const client = new MemoryStorage({ persistStorage: false });
 
-log.setLevel(log.LEVELS.DEBUG);
-
 export function getSearchCrawlerKey(cheerioCrawlerOptions: CheerioCrawlerOptions) {
     return JSON.stringify(cheerioCrawlerOptions);
 }

--- a/src/defaults.json
+++ b/src/defaults.json
@@ -1,7 +1,7 @@
 {
     "debugMode": false,
     "dynamicContentWaitSecs": 10,
-    "initialConcurrency": 3,
+    "initialConcurrency": 5,
     "keepAlive": true,
     "maxConcurrency": 10,
     "maxRequestRetries": 1,

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,5 +1,5 @@
 import { Actor } from 'apify';
-import { BrowserName, CheerioCrawlerOptions, PlaywrightCrawlerOptions } from 'crawlee';
+import { BrowserName, CheerioCrawlerOptions, log, PlaywrightCrawlerOptions } from 'crawlee';
 import { firefox } from 'playwright';
 
 import defaults from './defaults.json' with { type: 'json' };
@@ -32,6 +32,8 @@ export async function processInput(originalInput: Partial<Input>) {
         readableTextCharThreshold,
         removeCookieWarnings,
     } = input;
+
+    if (input.debugMode) log.setLevel(log.LEVELS.DEBUG);
 
     const proxySearch = await Actor.createProxyConfiguration({ groups: [proxyGroupSearch] });
     const cheerioCrawlerOptions: CheerioCrawlerOptions = {

--- a/src/input.ts
+++ b/src/input.ts
@@ -33,7 +33,8 @@ export async function processInput(originalInput: Partial<Input>) {
         removeCookieWarnings,
     } = input;
 
-    if (input.debugMode) log.setLevel(log.LEVELS.DEBUG);
+    // Log level can be controlled by the debugMode. We'll set it to DEBUG for all users for better debugging.
+    log.setLevel(log.LEVELS.DEBUG);
 
     const proxySearch = await Actor.createProxyConfiguration({ groups: [proxyGroupSearch] });
     const cheerioCrawlerOptions: CheerioCrawlerOptions = {


### PR DESCRIPTION
- Updated README.md to include tips on improving latency
- Set `initialConcurrency` to 5
- Set `minConcurrency` to 3