### PR TITLE
feat: handle errors when request is added to Playwright queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ This changelog summarizes all changes of the RAG Web Browser
 ### 2024-10-17
 
 🚀 Features
+- Handle errors when request is added to Playwright queue.
+  This will prevent the Cheerio crawler from repeating the same request multiple times.
+- Silence error: Could not parse CSS stylesheet as there is no way to fix it at our end
 - Set logLevel to INFO (debug level can be set using the `debugMode=true` input)
 
 ### 2024-10-11

--- a/src/crawlers.ts
+++ b/src/crawlers.ts
@@ -73,6 +73,8 @@ async function createAndStartSearchCrawler(
 
             // filter organic results to get only results with URL
             let results = organicResults.filter((result) => result.url !== undefined);
+            // remove results with URL starting with '/search?q=' (google return empty search results for images)
+            results = results.filter((result) => !result.url!.startsWith('/search?q='));
 
             // limit the number of search results to the maxResults
             results = results.slice(0, request.userData?.maxResults ?? results.length);
@@ -175,9 +177,13 @@ export const addPlaywrightCrawlRequest = async (
         log.error(`Playwright crawler not found: key ${playwrightCrawlerKey}`);
         return;
     }
-    await crawler.requestQueue!.addRequest(request);
-    // create an empty result in search request response
-    // do not use request.uniqueKey as responseId as it is not id of a search request
-    addEmptyResultToResponse(responseId, request);
-    log.info(`Added request to the playwright-content-crawler: ${request.url}`);
+    try {
+        await crawler.requestQueue!.addRequest(request);
+        // create an empty result in search request response
+        // do not use request.uniqueKey as responseId as it is not id of a search request
+        addEmptyResultToResponse(responseId, request);
+        log.info(`Added request to the playwright-content-crawler: ${request.url}`);
+    } catch (err) {
+        log.error(`Error adding request to playwright-content-crawler: ${request.url}, error: ${err}`);
+    }
 };

--- a/src/website-content-crawler/text-extractor.ts
+++ b/src/website-content-crawler/text-extractor.ts
@@ -1,7 +1,13 @@
 import { Readability, isProbablyReaderable } from '@mozilla/readability';
-import { JSDOM } from 'jsdom';
+import { log } from 'crawlee';
+import { JSDOM, VirtualConsole } from 'jsdom';
 
 import type { PlaywrightScraperSettings } from '../types.js';
+
+const virtualConsole = new VirtualConsole();
+virtualConsole.on('error', (error) => {
+    log.error(`JSDOM error: ${error}`);
+});
 
 /**
  * Extracts readable text from the HTML using Mozilla's Readability (source: Website Content Crawler).
@@ -19,7 +25,9 @@ export async function readableText({
         fallbackToNone?: boolean;
     };
 }): Promise<string | undefined> {
-    const dom = new JSDOM(html, { url });
+    // Add virtualConsole to silence this Error: Could not parse CSS stylesheet at exports.createStylesheet
+    // There is some issue with the VirtualConsole as the error is not logged
+    const dom = new JSDOM(html, { url, virtualConsole });
 
     if (options?.fallbackToNone && !isProbablyReaderable(dom.window.document, { minScore: 100 })) {
         return html;


### PR DESCRIPTION
* Handle errors when request is added to Playwright queue.
   This will prevent the Cheerio crawler from repeating the same request multiple times.
* Silence error: Could not parse CSS stylesheet as there is no way to fix it at our end