### PR TITLE
Fix: Standby mode spawns extra crawlers

### DIFF
--- a/.actor/input_schema.json
+++ b/.actor/input_schema.json
@@ -94,7 +94,7 @@
             "description": "The initial number of web browsers running in parallel. The system automatically scales the number based on the CPU and memory usage, in the range specified by `minConcurrency` and `maxConcurrency`. If the initial value is `0`, the Actor picks the number automatically based on the available memory.",
             "minimum": 0,
             "maximum": 50,
-            "default": 4,
+            "default": 5,
             "editor": "hidden"
         },
         "minConcurrency": {
@@ -103,7 +103,7 @@
             "description": "The minimum number of web browsers running in parallel.",
             "minimum": 1,
             "maximum": 50,
-            "default": 1,
+            "default": 3,
             "editor": "hidden"
         },
         "maxConcurrency": {

--- a/src/const.ts
+++ b/src/const.ts
@@ -29,7 +29,7 @@ export const defaults = {
     minConcurrency: inputSchema.properties.minConcurrency.default,
     outputFormats: inputSchema.properties.outputFormats.default,
     proxyConfiguration: inputSchema.properties.proxyConfiguration.default,
-    query: undefined, // No defult value in input_schema.json
+    query: undefined, // No default value in input_schema.json
     readableTextCharThreshold: 100, // Not in input_schema.json
     removeCookieWarnings: inputSchema.properties.removeCookieWarnings.default,
     removeElementsCssSelector: inputSchema.properties.removeElementsCssSelector.default,

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,3 +1,5 @@
+import inputSchema from '../.actor/input_schema.json' assert { type: 'json' };
+
 export enum ContentCrawlerStatus {
     PENDING = 'pending',
     HANDLED = 'handled',
@@ -12,29 +14,28 @@ export enum Routes {
 
 export const PLAYWRIGHT_REQUEST_TIMEOUT_NORMAL_MODE_SECS = 60;
 
-// TODO: It would be better to simply use input_schema.json rather then hard-coding these values,
-//  to ensure the values in NORMAL mode and STANDBY are consistent
+// Default values parsed from input_schema.json
 export const defaults = {
-    debugMode: false,
-    dynamicContentWaitSecs: 10,
-    htmlTransformer: 'none',
-    initialConcurrency: 5,
-    keepAlive: true,
-    maxConcurrency: 10,
-    maxRequestRetries: 1,
-    maxRequestRetriesMax: 3,
-    maxResults: 3,
-    maxResultsMax: 100,
-    minConcurrency: 3,
-    outputFormats: ['markdown'],
-    proxyConfiguration: { useApifyProxy: true },
-    query: null,
-    readableTextCharThreshold: 100,
-    removeCookieWarnings: true,
-    removeElementsCssSelector: "nav, footer, script, style, noscript, svg, img[src^='data:'],\n[role=\"alert\"],\n[role=\"banner\"],\n[role=\"dialog\"],\n[role=\"alertdialog\"],\n[role=\"region\"][aria-label*=\"skip\" i],\n[aria-modal=\"true\"]",
-    requestTimeoutSecs: 40,
-    requestTimeoutSecsMax: 300,
-    serpMaxRetries: 2,
-    serpMaxRetriesMax: 5,
-    serpProxyGroup: 'GOOGLE_SERP',
+    debugMode: inputSchema.properties.debugMode.default,
+    dynamicContentWaitSecs: inputSchema.properties.dynamicContentWaitSecs.default,
+    htmlTransformer: inputSchema.properties.htmlTransformer.default,
+    initialConcurrency: inputSchema.properties.initialConcurrency.default,
+    keepAlive: true, // Not in input_schema.json
+    maxConcurrency: inputSchema.properties.maxConcurrency.default,
+    maxRequestRetries: inputSchema.properties.maxRequestRetries.default,
+    maxRequestRetriesMax: inputSchema.properties.maxRequestRetries.maximum,
+    maxResults: inputSchema.properties.maxResults.default,
+    maxResultsMax: inputSchema.properties.maxResults.maximum,
+    minConcurrency: inputSchema.properties.minConcurrency.default,
+    outputFormats: inputSchema.properties.outputFormats.default,
+    proxyConfiguration: inputSchema.properties.proxyConfiguration.default,
+    query: undefined, // No defult value in input_schema.json
+    readableTextCharThreshold: 100, // Not in input_schema.json
+    removeCookieWarnings: inputSchema.properties.removeCookieWarnings.default,
+    removeElementsCssSelector: inputSchema.properties.removeElementsCssSelector.default,
+    requestTimeoutSecs: inputSchema.properties.requestTimeoutSecs.default,
+    requestTimeoutSecsMax: inputSchema.properties.requestTimeoutSecs.maximum,
+    serpMaxRetries: inputSchema.properties.serpMaxRetries.default,
+    serpMaxRetriesMax: inputSchema.properties.serpMaxRetries.maximum,
+    serpProxyGroup: inputSchema.properties.serpProxyGroup.default,
 };

--- a/src/crawlers.ts
+++ b/src/crawlers.ts
@@ -108,7 +108,7 @@ async function createAndStartSearchCrawler(
     if (startCrawler) {
         crawler.run().then(
             () => log.warning(`Google-search-crawler has finished`),
-            () => {},
+            () => { },
         );
         log.info('Google-search-crawler has started 🫡');
     }
@@ -135,9 +135,9 @@ async function createAndStartCrawlerPlaywright(
         ...(crawlerOptions as PlaywrightCrawlerOptions),
         keepAlive: crawlerOptions.keepAlive,
         requestQueue: await RequestQueue.open(key, { storageClient: client }),
-        requestHandler: (
-            context: PlaywrightCrawlingContext<PlaywrightCrawlerUserData>,
-        ) => requestHandlerPlaywright(context),
+        requestHandler: async (context: PlaywrightCrawlingContext) => {
+            await requestHandlerPlaywright(context as unknown as PlaywrightCrawlingContext<PlaywrightCrawlerUserData>);
+        },
         failedRequestHandler: ({ request }, err) => failedRequestHandlerPlaywright(request, err),
     });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { log } from 'crawlee';
 import express, { Request, Response } from 'express';
 
 import { Routes } from './const.js';
+import { createAndStartCrawlers } from './crawlers.js';
 import { processInput } from './input.js';
 import { RagWebBrowserServer } from './mcp/server.js';
 import { addTimeoutToAllResponses } from './responses.js';
@@ -74,7 +75,9 @@ if (standbyMode) {
     const host = Actor.isAtHome() ? process.env.ACTOR_STANDBY_URL : 'http://localhost';
     const port = Actor.isAtHome() ? process.env.ACTOR_STANDBY_PORT : 3000;
     app.listen(port, async () => {
+        // Pre-create default crawlers
         log.info(`The Actor web server is listening for user requests at ${host}.`);
+        await createAndStartCrawlers(cheerioCrawlerOptions, playwrightCrawlerOptions);
     });
 } else {
     log.info('Actor is running in the NORMAL mode.');

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,6 @@ import { log } from 'crawlee';
 import express, { Request, Response } from 'express';
 
 import { Routes } from './const.js';
-import { createAndStartCrawlers } from './crawlers.js';
 import { processInput } from './input.js';
 import { RagWebBrowserServer } from './mcp/server.js';
 import { addTimeoutToAllResponses } from './responses.js';
@@ -75,9 +74,7 @@ if (standbyMode) {
     const host = Actor.isAtHome() ? process.env.ACTOR_STANDBY_URL : 'http://localhost';
     const port = Actor.isAtHome() ? process.env.ACTOR_STANDBY_PORT : 3000;
     app.listen(port, async () => {
-        // Pre-create default crawlers
         log.info(`The Actor web server is listening for user requests at ${host}.`);
-        await createAndStartCrawlers(cheerioCrawlerOptions, playwrightCrawlerOptions, playwrightScraperSettings);
     });
 } else {
     log.info('Actor is running in the NORMAL mode.');

--- a/src/playwright-req-handler.ts
+++ b/src/playwright-req-handler.ts
@@ -4,7 +4,7 @@ import { htmlToText, log, PlaywrightCrawlingContext, sleep, Request } from 'craw
 
 import { ContentCrawlerStatus } from './const.js';
 import { addResultToResponse, sendResponseIfFinished } from './responses.js';
-import { Output, UserData } from './types.js';
+import { Output, PlaywrightCrawlerUserData } from './types.js';
 import { addTimeMeasureEvent, transformTimeMeasuresToRelative } from './utils.js';
 import { processHtml } from './website-content-crawler/html-processing.js';
 import { htmlToMarkdown } from './website-content-crawler/markdown.js';
@@ -59,14 +59,9 @@ function isValidContentType(contentType: string | undefined) {
 /**
  * Generic handler for processing the page content (adapted from: Website Content Crawler).
  */
-export async function requestHandlerPlaywright(context: PlaywrightCrawlingContext<UserData>) {
+export async function requestHandlerPlaywright(context: PlaywrightCrawlingContext<PlaywrightCrawlerUserData>) {
     const { request, contentType, page, response, closeCookieModals } = context;
     const { playwrightScraperSettings: settings, responseId } = request.userData;
-
-    if (!settings) {
-        log.error('Missing playwrightScraperSettings in request.userData');
-        return;
-    }
 
     log.info(`Processing URL: ${request.url}`);
     addTimeMeasureEvent(request.userData, 'playwright-request-start');

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -2,7 +2,7 @@ import { log } from 'apify';
 import { RequestOptions } from 'crawlee';
 
 import { ContentCrawlerStatus } from './const.js';
-import { Output, UserData } from './types.js';
+import { Output, PlaywrightCrawlerUserData } from './types.js';
 
 type ResponseData = {
     resultsMap: Map<string, Output>;
@@ -48,7 +48,7 @@ export function createResponsePromise(responseId: string, timeoutSecs: number): 
  * Add empty result to response object when the content crawler request is created.
  * This is needed to keep track of all results and to know that all results have been handled.
  */
-export function addEmptyResultToResponse(responseId: string, request: RequestOptions<UserData>) {
+export function addEmptyResultToResponse(responseId: string, request: RequestOptions<PlaywrightCrawlerUserData>) {
     const res = getResponse(responseId);
     if (!res) return;
 

--- a/src/search.ts
+++ b/src/search.ts
@@ -26,6 +26,7 @@ function prepareRequest(
     input: Input,
     cheerioCrawlerOptions: CheerioCrawlerOptions,
     playwrightCrawlerKey: string,
+    playwrightScraperSettings: PlaywrightScraperSettings,
 ) {
     const interpretedUrl = interpretAsUrl(input.query);
     const query = interpretedUrl ?? input.query;
@@ -35,6 +36,7 @@ function prepareRequest(
         ? createRequest(
             { url: query },
             responseId,
+            playwrightScraperSettings,
             null,
         )
         : createSearchRequest(
@@ -43,6 +45,7 @@ function prepareRequest(
             input.maxResults,
             playwrightCrawlerKey,
             cheerioCrawlerOptions.proxyConfiguration,
+            playwrightScraperSettings,
         );
 
     addTimeMeasureEvent(req.userData!, 'request-received', Date.now());
@@ -66,10 +69,14 @@ async function runSearchProcess(params: Partial<Input>): Promise<Output[]> {
     const { playwrightCrawlerKey } = await createAndStartCrawlers(
         cheerioCrawlerOptions,
         playwrightCrawlerOptions,
-        playwrightScraperSettings,
     );
 
-    const { req, isUrl, responseId } = prepareRequest(input, cheerioCrawlerOptions, playwrightCrawlerKey);
+    const { req, isUrl, responseId } = prepareRequest(
+        input,
+        cheerioCrawlerOptions,
+        playwrightCrawlerKey,
+        playwrightScraperSettings,
+    );
 
     // Create a promise that resolves when all requests are processed
     const resultsPromise = createResponsePromise(responseId, input.requestTimeoutSecs);
@@ -142,11 +149,15 @@ export async function handleSearchNormalMode(input: Input,
     const { playwrightCrawlerKey, searchCrawler, playwrightCrawler } = await createAndStartCrawlers(
         cheerioCrawlerOptions,
         playwrightCrawlerOptions,
-        playwrightScraperSettings,
         false,
     );
 
-    const { req, isUrl } = prepareRequest(input, cheerioCrawlerOptions, playwrightCrawlerKey);
+    const { req, isUrl } = prepareRequest(
+        input,
+        cheerioCrawlerOptions,
+        playwrightCrawlerKey,
+        playwrightScraperSettings,
+    );
     if (isUrl) {
         // If the input query is a URL, we don't need to run the search crawler
         log.info(`Skipping Google Search query because "${input.query}" is a valid URL.`);

--- a/src/search.ts
+++ b/src/search.ts
@@ -34,6 +34,7 @@ function prepareRequest(
 
     const req = interpretedUrl
         ? createRequest(
+            query,
             { url: query },
             responseId,
             playwrightScraperSettings,

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,7 @@ export type UserData = {
     timeMeasures?: TimeMeasure[];
     searchResult?: OrganicResult;
     playwrightCrawlerKey?: string;
+    playwrightScraperSettings?: PlaywrightScraperSettings;
 };
 
 export interface PlaywrightScraperSettings {

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,16 +64,21 @@ export interface TimeMeasure {
     timeDeltaPrevMs: number;
 }
 
-export type UserData = {
-    finishedAt?: Date;
-    maxResults?: number;
-    query?: string;
-    responseId?: string;
-    startedAt?: Date;
-    timeMeasures?: TimeMeasure[];
+export type SearchCrawlerUserData = {
+    maxResults: number;
+    timeMeasures: TimeMeasure[];
+    query: string;
+    playwrightCrawlerKey: string;
+    responseId: string;
+    playwrightScraperSettings: PlaywrightScraperSettings;
+};
+
+export type PlaywrightCrawlerUserData = {
+    query: string;
+    responseId: string;
+    timeMeasures: TimeMeasure[];
     searchResult?: OrganicResult;
-    playwrightCrawlerKey?: string;
-    playwrightScraperSettings?: PlaywrightScraperSettings;
+    playwrightScraperSettings: PlaywrightScraperSettings;
 };
 
 export interface PlaywrightScraperSettings {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -65,11 +65,7 @@ export function createSearchRequest(
 }
 
 /**
- * Create a request for Playwright crawler with the provided result, responseId and timeMeasures.
- * @param query
- * @param result
- * @param responseId
- * @param timeMeasures
+ * Create a request for Playwright crawler with the provided query, result, responseId and timeMeasures.
  */
 export function createRequest(
     query: string,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import { RequestOptions, log, ProxyConfiguration } from 'crawlee';
 import { parse, ParsedUrlQuery } from 'querystring';
 
 import { defaults } from './const.js';
-import { OrganicResult, TimeMeasure, UserData } from './types.js';
+import { OrganicResult, PlaywrightScraperSettings, TimeMeasure, UserData } from './types.js';
 
 export function parseParameters(url: string): ParsedUrlQuery {
     return parse(url.slice(1));
@@ -47,6 +47,7 @@ export function createSearchRequest(
     maxResults: number,
     playwrightCrawlerKey: string,
     proxyConfiguration: ProxyConfiguration | undefined,
+    playwrightScraperSettings: PlaywrightScraperSettings,
 ): RequestOptions<UserData> {
     // add some overhead for the maxResults to account for the fact that some results are not Organic
     const n = Number(maxResults) + 5;
@@ -59,7 +60,7 @@ export function createSearchRequest(
     return {
         url: urlSearch,
         uniqueKey: randomId(),
-        userData: { maxResults, timeMeasures: [], query, playwrightCrawlerKey, responseId },
+        userData: { maxResults, timeMeasures: [], query, playwrightCrawlerKey, responseId, playwrightScraperSettings },
     };
 }
 
@@ -72,6 +73,7 @@ export function createSearchRequest(
 export function createRequest(
     result: OrganicResult,
     responseId: string,
+    playwrightScraperSettings: PlaywrightScraperSettings,
     timeMeasures: TimeMeasure[] | null = null,
 ): RequestOptions<UserData> {
     return {
@@ -81,6 +83,7 @@ export function createRequest(
             responseId,
             searchResult: result.url && result.title ? result : undefined,
             timeMeasures: timeMeasures ? [...timeMeasures] : [],
+            playwrightScraperSettings,
         },
     };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import { RequestOptions, log, ProxyConfiguration } from 'crawlee';
 import { parse, ParsedUrlQuery } from 'querystring';
 
 import { defaults } from './const.js';
-import { OrganicResult, PlaywrightScraperSettings, TimeMeasure, UserData } from './types.js';
+import { OrganicResult, PlaywrightScraperSettings, TimeMeasure, PlaywrightCrawlerUserData, SearchCrawlerUserData } from './types.js';
 
 export function parseParameters(url: string): ParsedUrlQuery {
     return parse(url.slice(1));
@@ -48,7 +48,7 @@ export function createSearchRequest(
     playwrightCrawlerKey: string,
     proxyConfiguration: ProxyConfiguration | undefined,
     playwrightScraperSettings: PlaywrightScraperSettings,
-): RequestOptions<UserData> {
+): RequestOptions<SearchCrawlerUserData> {
     // add some overhead for the maxResults to account for the fact that some results are not Organic
     const n = Number(maxResults) + 5;
 
@@ -66,20 +66,23 @@ export function createSearchRequest(
 
 /**
  * Create a request for Playwright crawler with the provided result, responseId and timeMeasures.
+ * @param query
  * @param result
  * @param responseId
  * @param timeMeasures
  */
 export function createRequest(
+    query: string,
     result: OrganicResult,
     responseId: string,
     playwrightScraperSettings: PlaywrightScraperSettings,
     timeMeasures: TimeMeasure[] | null = null,
-): RequestOptions<UserData> {
+): RequestOptions<PlaywrightCrawlerUserData> {
     return {
         url: result.url!,
         uniqueKey: randomId(),
         userData: {
+            query,
             responseId,
             searchResult: result.url && result.title ? result : undefined,
             timeMeasures: timeMeasures ? [...timeMeasures] : [],
@@ -88,7 +91,7 @@ export function createRequest(
     };
 }
 
-export function addTimeMeasureEvent(userData: UserData, event: TimeMeasure['event'], time: number | null = null) {
+export function addTimeMeasureEvent(userData: PlaywrightCrawlerUserData, event: TimeMeasure['event'], time: number | null = null) {
     let timePrev = 0;
     if (!userData.timeMeasures?.length) {
         userData.timeMeasures = [];


### PR DESCRIPTION
Fixes #50.

Refactors the PlaywrightScraperSettings into UserData. This reduces the amount of create crawlers. New crawlers are only created when changing settings related directly to the crawler (eg. `maxRequestRetries`).

I have also removed pre-creation of crawlers in standby mode as the requested crawlers could have different settings and the overhead of creating crawlers is small.

cc: @metalwarrior665 @jirispilka 