### PR TITLE
fix: add block media feature for playwright - blocks images, videos, css

### DIFF
--- a/.actor/input_schema.json
+++ b/.actor/input_schema.json
@@ -145,6 +145,12 @@
             "description": "If enabled, the Actor attempts to close or remove cookie consent dialogs to improve the quality of extracted text. Note that this setting increases the latency.",
             "default": true
         },
+        "blockMedia": {
+            "title": "Block media resources",
+            "type": "boolean",
+            "description": "If enabled, the Actor will block loading of images, videos and CSS resources when using the Playwright browser. This can improve performance and reduce bandwidth usage.",
+            "default": false
+        },
         "debugMode": {
             "title": "Enable debug mode",
             "type": "boolean",

--- a/src/input.ts
+++ b/src/input.ts
@@ -111,6 +111,27 @@ function createPlaywrightCrawlerOptions(input: Input, proxy: ProxyConfiguration 
                 maxConcurrency,
                 minConcurrency,
             },
+            preNavigationHooks: input.blockMedia ? [
+                async ({ page }) => {
+                    await page.route('**/*', async (route) => {
+                        const resourceType = route.request().resourceType();
+                        const url = route.request().url();
+
+                        // Block if it's an image/video/css resource type or has an image/video extension
+                        if (
+                            resourceType === 'image'
+                            || resourceType === 'video'
+                            || resourceType === 'media'
+                            || resourceType === 'stylesheet'
+                            || /\.(jpg|jpeg|png|gif|bmp|webp|mp4|webm|ogg|mov|css)$/i.test(url)
+                        ) {
+                            await route.abort();
+                        } else {
+                            await route.continue();
+                        }
+                    });
+                },
+            ] : [],
         },
     };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export type Input = {
     removeElementsCssSelector: string;
     removeCookieWarnings: boolean;
     scrapingTool: 'browser-playwright' | 'raw-http';
+    blockMedia: boolean;
 };
 
 export type StandbyInput = Input & {


### PR DESCRIPTION
closes https://github.com/apify/rag-web-browser/issues/47#event-16259291157