### PR TITLE
fix: return dataset it on request timeout

### DIFF
--- a/src/responses.ts
+++ b/src/responses.ts
@@ -39,7 +39,8 @@ export function createResponsePromise(responseId: string, timeoutSecs: number): 
 
         // Set a timeout to reject the promise if it takes too long
         data.timeoutId = setTimeout(() => {
-            sendResponseError(responseId, 'Timed out');
+            const defaultDatasetId = process.env.ACTOR_DEFAULT_DATASET_ID;
+            sendResponseError(responseId, `Timed out. Please check the dataset ${defaultDatasetId} for results.`);
         }, timeoutSecs * 1000);
     });
 }


### PR DESCRIPTION
Since we cannot remove request that are already being crawled we just return dataset id on timeout so the user knows where to check for results - as we discussed.

closes https://github.com/apify/rag-web-browser/issues/31