### PR TITLE
fix: Final status message with scraping statistics

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -64,11 +64,12 @@ if (isActorStandby()) {
         contentScraperSettings ${JSON.stringify(contentScraperSettings)}
     `);
 
+    let stats = { requestsFinished: 0, requestsFailed: 0 };
     try {
-        await handleSearchNormalMode(input, searchCrawlerOptions, contentCrawlerOptions, contentScraperSettings);
+        stats = await handleSearchNormalMode(input, searchCrawlerOptions, contentCrawlerOptions, contentScraperSettings);
     } catch (e) {
         const error = e as Error;
         await Actor.fail(error.message as string);
     }
-    await Actor.exit();
+    await Actor.exit(`Finished! Scraped ${stats.requestsFinished} pages, ${stats.requestsFailed} failed.`);
 }

--- a/src/search.ts
+++ b/src/search.ts
@@ -174,4 +174,7 @@ export async function handleSearchNormalMode(input: Input,
     log.info(`Running target page crawler with request: ${JSON.stringify(req)}`);
     await contentCrawler!.run();
     /* eslint-enable no-param-reassign */
+
+    const { requestsFinished, requestsFailed } = contentCrawler!.stats.state;
+    return { requestsFinished, requestsFailed };
 }


### PR DESCRIPTION
The Actor left statusMessage empty and therefore MCP was not able to retrieve it.