### PR TITLE
fix: guard against invalid hostname

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -18,7 +18,6 @@ import type {
     SERPProxyGroup,
     UrlToMarkdownInput,
 } from './types.js';
-import { interpretAsUrl } from './utils.js';
 
 /**
  * Processes the input and returns an array of crawler settings. This is ideal for startup of STANDBY mode
@@ -101,10 +100,9 @@ async function processRagWebBrowserInput(input: Partial<RagWebBrowserInput>, sta
     }> {
     /* eslint-disable no-param-reassign */
 
-    // Throw an error if the query and is not provided and standbyInit is false.
-    if (!input.query && !standbyInit) {
-        throw new UserInputError('The `query` parameter must be provided and non-empty.');
-    }
+    // Note: `query` is intentionally not validated here. It is a per-request property (depending on
+    // the mini-actor) rather than a startup/crawler-configuration property, so its presence and validity
+    // are checked when the request is actually formed (see `prepareRequest` in search.ts).
 
     // Max results
     input.maxResults = validateRange(
@@ -183,17 +181,10 @@ async function processRagWebBrowserInput(input: Partial<RagWebBrowserInput>, sta
 }
 
 async function processUrlToMarkdownInput(input: Partial<UrlToMarkdownInput>): Promise<UrlToMarkdownInput> {
-    if (!input.url) {
-        throw new UserInputError('The `url` parameter must be provided and non-empty.');
-    }
-    const interpretedUrl = interpretAsUrl(input.url!);
-    if (!interpretedUrl) {
-        throw new UserInputError('The `url` parameter must be a valid URL or a string that can be interpreted as a URL.');
-    }
-    if (interpretedUrl) {
-        // eslint-disable-next-line no-param-reassign
-        input.url = interpretedUrl;
-    }
+    // Note: `url` is intentionally not validated or interpreted here. It is a per-request property
+    // rather than a startup/crawler-configuration property, so its presence and validity are checked
+    // when the request is actually formed (see `prepareRequest` in search.ts).
+
     // We default to the only supported output format for this mini-actor, no choice for the user
     // eslint-disable-next-line no-param-reassign
     input.outputFormats = ['markdown'];
@@ -280,7 +271,6 @@ function createCheerioCrawlerOptions(
 
 /**
  * Validates the input and fills in the default values where necessary.
- * This is a bit ugly, but it's necessary to avoid throwing an error when the query is not provided in standby mode.
  */
 function validateAndFillInput(input: Partial<Input>): Input {
     /* eslint-disable no-param-reassign */

--- a/src/input.ts
+++ b/src/input.ts
@@ -67,7 +67,7 @@ async function processInputInternal(
         input = processedRagWebBrowserInput.validatedRagBrowserInput;
         searchCrawlerOptions = processedRagWebBrowserInput.searchCrawlerOptions;
     } else {
-        input = await processUrlToMarkdownInput(originalInput as Partial<UrlToMarkdownInput>, standbyInit);
+        input = await processUrlToMarkdownInput(originalInput as Partial<UrlToMarkdownInput>);
     }
 
     const {
@@ -182,12 +182,12 @@ async function processRagWebBrowserInput(input: Partial<RagWebBrowserInput>, sta
     /* eslint-enable no-param-reassign */
 }
 
-async function processUrlToMarkdownInput(input: Partial<UrlToMarkdownInput>, standbyInit: boolean): Promise<UrlToMarkdownInput> {
-    if (!input.url && !standbyInit) {
+async function processUrlToMarkdownInput(input: Partial<UrlToMarkdownInput>): Promise<UrlToMarkdownInput> {
+    if (!input.url) {
         throw new UserInputError('The `url` parameter must be provided and non-empty.');
     }
     const interpretedUrl = interpretAsUrl(input.url!);
-    if (!interpretedUrl && !standbyInit) {
+    if (!interpretedUrl) {
         throw new UserInputError('The `url` parameter must be a valid URL or a string that can be interpreted as a URL.');
     }
     if (interpretedUrl) {

--- a/src/search.ts
+++ b/src/search.ts
@@ -32,11 +32,19 @@ function prepareRequest(
     userAuthorization?: string,
 ) {
     if (!getMiniActor().runsSearch) {
-        const responseId = randomId();
         const { url } = (input as Input & UrlToMarkdownInput);
+        if (!url) {
+            throw new UserInputError('The `url` parameter must be provided and non-empty.');
+        }
+        const interpretedUrl = interpretAsUrl(url);
+        if (!interpretedUrl) {
+            throw new UserInputError('The `url` parameter must be a valid URL or a string that can be interpreted as a URL.');
+        }
+
+        const responseId = randomId();
         const req = createRequest(
-            url,
-            { url },
+            interpretedUrl,
+            { url: interpretedUrl },
             responseId,
             contentScraperSettings,
             null,
@@ -47,6 +55,9 @@ function prepareRequest(
     }
 
     const { query, maxResults } = input as Input & RagWebBrowserInput;
+    if (!query) {
+        throw new UserInputError('The `query` parameter must be provided and non-empty.');
+    }
     const interpretedUrl = interpretAsUrl(query);
     const validatedQuery = interpretedUrl ?? query;
     const responseId = randomId();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -238,7 +238,9 @@ export function interpretAsUrl(input: string): string | null {
 
         try {
             const url = new URL(trimmed);
-            if (/^https?:/i.test(url.protocol)) return url.href;
+            const hasValidProtocol = /^https?:/i.test(url.protocol);
+            const hasValidHostname = url.hostname.split('.').length > 1 || url.hostname === 'localhost';
+            if (hasValidProtocol && hasValidHostname) return url.href;
         } catch {
             // Continue by checking whether this is a supported URL without a protocol.
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -239,7 +239,7 @@ export function interpretAsUrl(input: string): string | null {
         try {
             const url = new URL(trimmed);
             const hasValidProtocol = /^https?:/i.test(url.protocol);
-            const hasValidHostname = url.hostname.split('.').length > 1 || url.hostname === 'localhost';
+            const hasValidHostname = url.hostname.split('.').filter(Boolean).length > 1 || url.hostname === 'localhost';
             if (hasValidProtocol && hasValidHostname) return url.href;
         } catch {
             // Continue by checking whether this is a supported URL without a protocol.


### PR DESCRIPTION
Closes #88 

Query and url where not checked at all at input, letting the scraper fail when trying to do something with it. This was done to avoid the standby failing at startup.

Now the checks are moved inside the search/fetch workflow and the input checks only what kind of crawlers it has to warmup.