### PR TITLE
chore: switch from readableText to readableTextIfPossible

### DIFF
--- a/actors/apify_rag-web-browser/.actor/input_schema.json
+++ b/actors/apify_rag-web-browser/.actor/input_schema.json
@@ -111,7 +111,7 @@
             "htmlTransformer": {
                 "title": "HTML transformer",
                 "type": "string",
-                "description": "Specify how to transform the HTML to extract meaningful content without any extra fluff, like navigation or modals. The HTML transformation happens after removing and clicking the DOM elements.\n\n- **None** (default) - Only removes the HTML elements specified via 'Remove HTML elements' option.\n\n- **Readable text** - Extracts the main contents of the webpage, without navigation and other fluff.",
+                "description": "Specify how to transform the HTML to extract meaningful content without any extra fluff, like navigation or modals. The HTML transformation happens after removing and clicking the DOM elements.\n\n- **None** (default) - Only removes the HTML elements specified via 'Remove HTML elements' option.\n\n- **Readable text** - Extracts the main contents of the webpage, without navigation and other fluff. If readability is not confident or fails, it keeps the original cleaned HTML instead of returning an empty or broken result.",
                 "default": "none",
                 "prefill": "none",
                 "editor": "hidden"

--- a/src/website-content-crawler/html-processing.ts
+++ b/src/website-content-crawler/html-processing.ts
@@ -33,9 +33,9 @@ export async function processHtml(
         : (html ?? '');
 
     let ret = null;
-    if (settings.htmlTransformer === 'readableText') {
+    if (settings.htmlTransformer === 'readableTextIfPossible' || settings.htmlTransformer === 'readableText') {
         try {
-            ret = await readableText({ html: simplified, url, options: { fallbackToNone: false } });
+            ret = await readableText({ html: simplified, url, options: { fallbackToNone: true } });
         } catch (error) {
             log.warning(`Processing of HTML failed with error:`, { error });
         }

--- a/src/website-content-crawler/html-processing.ts
+++ b/src/website-content-crawler/html-processing.ts
@@ -33,7 +33,7 @@ export async function processHtml(
         : (html ?? '');
 
     let ret = null;
-    if (settings.htmlTransformer === 'readableTextIfPossible' || settings.htmlTransformer === 'readableText') {
+    if (settings.htmlTransformer === 'readableText') {
         try {
             ret = await readableText({ html: simplified, url, options: { fallbackToNone: true } });
         } catch (error) {


### PR DESCRIPTION
Enable `fallbackToNone` for the readable-text transformer, so it keeps the cleaned HTML when Readability isn't confident or fails, instead of returning an empty/over-stripped result.

- accept `readableTextIfPossible` (canonical) and keep `readableText` as alias
- document the behavior in the input schema description

Closes #108