### PR TITLE
fix: fall back to cleaned HTML when Readability extracts no content

### DIFF
--- a/src/website-content-crawler/text-extractor.ts
+++ b/src/website-content-crawler/text-extractor.ts
@@ -36,6 +36,10 @@ export async function readableText({
 
     const readabilityRoot = parsed?.content as HTMLElement | null;
 
+    if (options?.fallbackToNone && !readabilityRoot?.textContent?.trim()) {
+        return html;
+    }
+
     if (readabilityRoot && parsed?.title) {
         const titleElement = dom.window.document.createElement('h1');
         titleElement.textContent = parsed.title;


### PR DESCRIPTION
follow up to https://github.com/apify/actor-rag-web-browser/pull/119

more bulletproof addition to fallbackToNone: true. If readability completely failed -> process raw html

Closes #108