### PR TITLE
fix: resolve relative markdown links against page URL

### DIFF
--- a/actors/apify_rag-web-browser/README.md
+++ b/actors/apify_rag-web-browser/README.md
@@ -15,6 +15,7 @@ The extracted text can then be injected into prompts and retrieval augmented gen
 - 🔄 **Flexible scraping** with Browser mode for complex websites or Plain HTML mode for faster scraping
 - 🕷 Automatically **bypasses anti-scraping protections** using proxies and browser fingerprints
 - 📝 Output formats include **Markdown**, plain text, and HTML
+- 🔗 **Links are converted to absolute URLs**, so they stay valid outside of the page they came from
 - 🔌 Supports **OpenAPI and MCP** for easy integration
 - 🪟 It's **open source**, so you can review and modify it
 

--- a/actors/apify_url-to-markdown/README.md
+++ b/actors/apify_url-to-markdown/README.md
@@ -82,6 +82,8 @@ Markdown is the perfect format to feed large language model (LLM). It is a less 
 
 Using markdown instead of html can help you lower the AI token cost.
 
+Relative links such as `/docs` are resolved into absolute URLs against the page they were found on, so they remain valid when the markdown is passed to an LLM.
+
 
 ### Can I use URL to Markdown with the Apify API?
 The Apify API gives you programmatic access to the Apify platform. The API is organized around RESTful HTTP endpoints that enable you to manage, schedule, and run Apify Actors. The API also lets you access any datasets, monitor Actor performance, fetch results, create and update versions, and more.

--- a/src/request-handler.ts
+++ b/src/request-handler.ts
@@ -144,7 +144,9 @@ async function handleContent(
         },
         query: request.userData.query,
         text: settings.outputFormats.includes('text') ? text : undefined,
-        markdown: settings.outputFormats.includes('markdown') ? htmlToMarkdown(processedHtml) : undefined,
+        markdown: settings.outputFormats.includes('markdown')
+            ? htmlToMarkdown(processedHtml, request.loadedUrl ?? request.url)
+            : undefined,
         html: settings.outputFormats.includes('html') ? processedHtml : undefined,
     };
 

--- a/src/website-content-crawler/markdown.ts
+++ b/src/website-content-crawler/markdown.ts
@@ -1,28 +1,60 @@
 import { log } from 'apify';
 import plugin from 'joplin-turndown-plugin-gfm';
-import TurndownService from 'turndown';
+import TurndownService, { type Rule } from 'turndown';
 
 const turndownSettings = {
     headingStyle: 'atx',
     codeBlockStyle: 'fenced',
 } as const;
 
-const githubFlavouredHtmlToMarkdownProcessor = new TurndownService(turndownSettings);
-const htmlToMarkdownProcessor = new TurndownService(turndownSettings);
+const GFM_MAX_HTML_LENGTH = 100_000;
 
-githubFlavouredHtmlToMarkdownProcessor.use(plugin.gfm); // Use GitHub Flavored Markdown
+function cleanAttribute(attribute: string | null): string {
+    return attribute ? attribute.replace(/(\n+\s*)+/g, '\n') : '';
+}
+
+function resolveHref(href: string, baseUrl: string): string {
+    if (!baseUrl) return href;
+    try {
+        return new URL(href, baseUrl).toString();
+    } catch {
+        log.warning(`Failed to resolve link against the page URL: ${href}`);
+        return href;
+    }
+}
+
+/**
+ * Turndown's built-in `inlineLink` rule, extended to resolve relative hrefs against `baseUrl` so that
+ * links such as `/docs` remain valid once the markdown is used outside of the source page.
+ * @see https://github.com/mixmark-io/turndown/blob/master/src/commonmark-rules.js
+ */
+const inlineLinkRule = (baseUrl: string): Rule => ({
+    filter: (node, options) => options.linkStyle === 'inlined'
+        && node.nodeName === 'A'
+        && Boolean(node.getAttribute('href')),
+    replacement: (content, node) => {
+        const element = node as HTMLElement;
+        const href = resolveHref(element.getAttribute('href')!, baseUrl).replace(/([()])/g, '\\$1');
+        const title = cleanAttribute(element.getAttribute('title'));
+        return `[${content}](${href}${title ? ` "${title.replace(/"/g, '\\"')}"` : ''})`;
+    },
+});
 
 /**
  * Converts HTML to markdown using Turndown (source: Website Content Crawler).
+ * Relative links are resolved against `url`, when provided.
  */
-export const htmlToMarkdown = (html: string | null): string | null => {
+export const htmlToMarkdown = (html: string | null, url?: string): string | null => {
     try {
         if (!html?.length) return null;
 
-        if (html.length <= 100000) {
-            return githubFlavouredHtmlToMarkdownProcessor.turndown(html);
+        const processor = new TurndownService(turndownSettings);
+        if (html.length <= GFM_MAX_HTML_LENGTH) {
+            processor.use(plugin.gfm); // Use GitHub Flavored Markdown
         }
-        return htmlToMarkdownProcessor.turndown(html);
+        processor.addRule('inlineLink', inlineLinkRule(url ?? ''));
+
+        return processor.turndown(html);
     } catch (err: unknown) {
         if (err instanceof Error) {
             log.exception(err, `Error while extracting markdown from HTML: ${err.message}`);

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -1,0 +1,62 @@
+import { log } from 'apify';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { htmlToMarkdown } from '../src/website-content-crawler/markdown.js';
+
+// The query string is part of the base on purpose: it has to survive a fragment-only href.
+const PAGE_URL = 'https://example.com/a/b?q=1';
+
+const TABLE = '<table><tr><th>a</th></tr><tr><td>1</td></tr></table>';
+
+// Enough padding to push a document over GFM_MAX_HTML_LENGTH.
+const PADDING = `<p>${'x'.repeat(100_001)}</p>`;
+
+describe('htmlToMarkdown', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it.each([
+        { name: 'root-relative', href: '/docs', resolved: 'https://example.com/docs' },
+        { name: 'path-relative', href: 'sub/page', resolved: 'https://example.com/a/sub/page' },
+        { name: 'fragment-only', href: '#sec', resolved: 'https://example.com/a/b?q=1#sec' },
+        { name: 'already absolute', href: 'https://other.com/x', resolved: 'https://other.com/x' },
+        { name: 'non-HTTP scheme', href: 'mailto:a@b.c', resolved: 'mailto:a@b.c' },
+    ])('should resolve a $name href against the page URL', ({ href, resolved }) => {
+        expect(htmlToMarkdown(`<a href="${href}">text</a>`, PAGE_URL)).toBe(`[text](${resolved})`);
+    });
+
+    it('should keep hrefs relative and stay quiet when no page URL is given', () => {
+        const warning = vi.spyOn(log, 'warning');
+
+        expect(htmlToMarkdown('<a href="/docs">text</a>')).toBe('[text](/docs)');
+        expect(warning).not.toHaveBeenCalled();
+    });
+
+    it('should keep the href and warn when it cannot be resolved', () => {
+        const warning = vi.spyOn(log, 'warning').mockImplementation(() => undefined);
+
+        expect(htmlToMarkdown('<a href="http://[">text</a>', PAGE_URL)).toBe('[text](http://[)');
+        expect(warning).toHaveBeenCalledOnce();
+    });
+
+    it('should keep the title of a resolved link and escape parentheses in its href', () => {
+        expect(htmlToMarkdown('<a href="/a(b)c" title="My title">text</a>', PAGE_URL))
+            .toBe('[text](https://example.com/a\\(b\\)c "My title")');
+    });
+
+    it('should return null for empty html', () => {
+        expect(htmlToMarkdown('', PAGE_URL)).toBeNull();
+    });
+
+    it('should convert tables using GitHub Flavored Markdown', () => {
+        expect(htmlToMarkdown(TABLE, PAGE_URL)).toContain('| --- |');
+    });
+
+    it('should skip GFM but still resolve links above the size limit', () => {
+        const markdown = htmlToMarkdown(`<a href="/docs">text</a>${TABLE}${PADDING}`, PAGE_URL);
+
+        expect(markdown).toContain('[text](https://example.com/docs)');
+        expect(markdown).not.toContain('| --- |');
+    });
+});


### PR DESCRIPTION
Closes #107.

Ports the link handling from Website Content Crawler: relative links are now resolved into absolute URLs against the page URL.

The base is `request.loadedUrl ?? request.url` (same as WCC), so links stay correct when a request gets redirected.

### Performance:
Conversion costs +0.02 ms on a typical page and +0.94 ms (20%) on a link-heavy
one (600 links).