### PR TITLE
fix: gracefully abort the run when Apify Proxy is unusable

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -212,9 +212,6 @@ async function processUrlToMarkdownInput(input: Partial<UrlToMarkdownInput>): Pr
 }
 
 async function createContentProxyConfiguration(proxyConfiguration: ProxyConfigurationOptions) {
-    // A malformed configuration is a user input error, so validate it before checking the proxy access.
-    await Actor.createProxyConfiguration({ ...proxyConfiguration, checkAccess: false });
-
     try {
         return await Actor.createProxyConfiguration(proxyConfiguration);
     } catch (e) {

--- a/src/input.ts
+++ b/src/input.ts
@@ -19,6 +19,7 @@ import type {
     SERPProxyGroup,
     UrlToMarkdownInput,
 } from './types.js';
+import { abortRun } from './utils.js';
 
 /**
  * Processes the input and returns an array of crawler settings. This is ideal for startup of STANDBY mode
@@ -27,7 +28,7 @@ import type {
 export async function processStandbyInput(originalInput: Partial<Input>) {
     const { input, searchCrawlerOptions, contentScraperSettings } = await processInputInternal(originalInput, true);
 
-    const proxy = await Actor.createProxyConfiguration(input.proxyConfiguration);
+    const proxy = await createContentProxyConfiguration(input.proxyConfiguration);
     const contentCrawlerOptions: ContentCrawlerOptions[] = [
         createPlaywrightCrawlerOptions(input, proxy),
         createCheerioCrawlerOptions(input, proxy),
@@ -42,7 +43,7 @@ export async function processStandbyInput(originalInput: Partial<Input>) {
 export async function processInput(originalInput: Partial<Input>) {
     const { input, searchCrawlerOptions, contentScraperSettings } = await processInputInternal(originalInput);
 
-    const proxy = await Actor.createProxyConfiguration(input.proxyConfiguration);
+    const proxy = await createContentProxyConfiguration(input.proxyConfiguration);
     const contentCrawlerOptions: ContentCrawlerOptions = input.scrapingTool === 'raw-http'
         ? createCheerioCrawlerOptions(input, proxy, false)
         : createPlaywrightCrawlerOptions(input, proxy, false);
@@ -208,6 +209,17 @@ async function processUrlToMarkdownInput(input: Partial<UrlToMarkdownInput>): Pr
 
     const validatedInput = validateAndFillInput(input) as UrlToMarkdownInput;
     return validatedInput;
+}
+
+async function createContentProxyConfiguration(proxyConfiguration: ProxyConfigurationOptions) {
+    // A malformed configuration is a user input error, so validate it before checking the proxy access.
+    await Actor.createProxyConfiguration({ ...proxyConfiguration, checkAccess: false });
+
+    try {
+        return await Actor.createProxyConfiguration(proxyConfiguration);
+    } catch (e) {
+        return abortRun(`Cannot use Apify Proxy for scraping the target pages: ${(e as Error).message}`);
+    }
 }
 
 function createPlaywrightCrawlerOptions(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ import { parse } from 'node:querystring';
 
 import { Actor } from 'apify';
 import type { ProxyConfiguration, RequestOptions } from 'crawlee';
-import { log } from 'crawlee';
+import { log, sleep } from 'crawlee';
 
 import ragWebBrowserInputSchema from '../actors/apify_rag-web-browser/.actor/input_schema.json' with { type: 'json' };
 import urlToMarkdownInputSchema from '../actors/apify_url-to-markdown/.actor/input_schema.json' with { type: 'json' };
@@ -45,6 +45,23 @@ const DOMAIN_LABEL_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i;
 
 export function isActorStandby(): boolean {
     return Actor.getEnv().metaOrigin === 'STANDBY';
+}
+
+/**
+ * Aborts the run with a terminal status message, instead of crashing or failing it.
+ */
+export async function abortRun(statusMessage: string): Promise<never> {
+    log.error(statusMessage);
+
+    if (!Actor.isAtHome()) {
+        process.exit(1);
+    }
+
+    await Actor.abort(Actor.getEnv().actorRunId!, { statusMessage, gracefully: true });
+    // Wait for the `aborting` event, on which the SDK shuts the Actor down.
+    while (true) {
+        await sleep(1000);
+    }
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ import { parse } from 'node:querystring';
 
 import { Actor } from 'apify';
 import type { ProxyConfiguration, RequestOptions } from 'crawlee';
-import { log, sleep } from 'crawlee';
+import { log } from 'crawlee';
 
 import ragWebBrowserInputSchema from '../actors/apify_rag-web-browser/.actor/input_schema.json' with { type: 'json' };
 import urlToMarkdownInputSchema from '../actors/apify_url-to-markdown/.actor/input_schema.json' with { type: 'json' };
@@ -57,11 +57,10 @@ export async function abortRun(statusMessage: string): Promise<never> {
         process.exit(1);
     }
 
+    // Aborting gracefully buys the 30 seconds that the teardown needs before the container is stopped.
     await Actor.abort(Actor.getEnv().actorRunId!, { statusMessage, gracefully: true });
-    // Wait for the `aborting` event, on which the SDK shuts the Actor down.
-    while (true) {
-        await sleep(1000);
-    }
+    await Actor.exit({ exit: false });
+    process.exit(0);
 }
 
 /**


### PR DESCRIPTION
When the user's proxy fails, the run now is gracefully aborted with a terminal status message. 

Closes #44